### PR TITLE
Persist subnet cache to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,39 @@ then
 
 `clouddetect -ip=127.0.0.1`
 
+## Caching to Disk
+
+```
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "github.com/99designs/clouddetect"
+    "time"
+)
+
+var (
+    client = clouddetect.NewClient(24 * time.Hour)
+)
+
+func init() {
+    client.CacheFilePath = path.Join(os.TempDir(), "cloud-ip-cache.json")
+    // Cache will be persisted and loaded from disk. A lock file is also generated during this process to allow multiple instances to share the same cache file path without having competing refreshes.
+    client.RefreshCache()
+}
+
+func main() {
+    ip := net.ParseIP("127.0.0.1")
+    if cloud, err := client.Resolve(ip); err == nil {
+        fmt.Println(cloud.ProviderName)
+    }
+}
+```
+
+Using a `CacheFilePath` speeds up the initial launch time, so your first request to resolve an IP will only be slow if no local cache exists. Optionally, manually calling the `client.RefreshCache()` function in your `init()` ensures your cache is ready to go even for the first request.
+
 ## LICENSE
 
 [MIT](/LICENSE) 2018 99designs

--- a/clouddetect.go
+++ b/clouddetect.go
@@ -1,8 +1,12 @@
 package clouddetect
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"net"
+	"os"
 	"sync"
 	"time"
 )
@@ -12,22 +16,29 @@ type Client struct {
 	// unexported cache storage
 	subnetCache    []*Response
 	cacheWriteTime time.Time
-	cacheMutex     *sync.Mutex
+	cacheMutex     *sync.RWMutex
+	cacheSource    string
 
 	// Time to keep IP ranges cached for (default 12 hours)
-	TTL time.Duration
+	TTL           time.Duration
+	CacheFilePath string
 }
 
 // Response provides details of the cloud environment the IP resolved to
+type diskCache struct {
+	SubnetCache []*Response `json:"cache"`
+}
 type Response struct {
-	ProviderName string
-	Region       string
-	Subnet       *net.IPNet
+	ProviderName string     `json:"providerName"`
+	Region       string     `json:"region"`
+	Subnet       *net.IPNet `json:"subnet"`
 }
 
 var (
 	// ErrNotCloudIP is error returned when IP does not match any of the published list of ranges
-	ErrNotCloudIP = errors.New("not resolved to any known cloud IP range")
+	ErrNotCloudIP      = errors.New("not resolved to any known cloud IP range")
+	ErrCacheNotReady   = errors.New("subnet cache is still being downloaded")
+	ErrCacheFileLocked = errors.New("cache lock file exists, skipping cache refresh")
 )
 
 const (
@@ -37,13 +48,15 @@ const (
 	ProviderGoogle = "Google Cloud"
 	// ProviderMicrosoft is Microsoft Azure
 	ProviderMicrosoft = "Microsoft Azure"
+	cacheSourceDisk   = "Disk"
+	cacheSourceWeb    = "Web"
 )
 
 // NewClient generates a Client with specified cache TTL
 func NewClient(TTL time.Duration) *Client {
 	return &Client{
 		TTL:        TTL,
-		cacheMutex: &sync.Mutex{},
+		cacheMutex: &sync.RWMutex{},
 	}
 }
 
@@ -62,49 +75,157 @@ func Resolve(ip net.IP) (*Response, error) {
 	return DefaultClient().Resolve(ip)
 }
 
-func (c *Client) allSubnetsForProviders() ([]*Response, error) {
-	c.cacheMutex.Lock()
-	if c.subnetCache == nil || c.cacheWriteTime.Add(c.TTL).Before(time.Now()) {
-		c.subnetCache = []*Response{}
-
-		amazon, err := getAmazonCIDRs()
-		if err != nil {
-			return nil, err
-		}
-		c.subnetCache = append(c.subnetCache, amazon...)
-
-		google, err := getGoogleCIDRs()
-		if err != nil {
-			return nil, err
-		}
-		c.subnetCache = append(c.subnetCache, google...)
-
-		microsoft, err := getMicrosoftCIDRs()
-		if err != nil {
-			return nil, err
-		}
-		c.subnetCache = append(c.subnetCache, microsoft...)
-		c.cacheWriteTime = time.Now()
-	}
-	c.cacheMutex.Unlock()
-
-	return c.subnetCache, nil
-}
-
 // Resolve will take the given ip and determine if it exists within any of the major
 // cloud providers' published IP ranges and any extra metadata that may be of use.
 // It returns ErrNotCloudIP if the IP does not resolve against any lists
-func (c *Client) Resolve(ip net.IP) (*Response, error) {
-	subNets, err := c.allSubnetsForProviders()
-	if err != nil {
-		return nil, err
+func (c *Client) Resolve(ip net.IP) (response *Response, err error) {
+	c.cacheMutex.RLock()
+	if len(c.subnetCache) == 0 || c.cacheWriteTime.Add(c.TTL).Before(time.Now()) {
+		c.cacheMutex.RUnlock()
+
+		// Ensure future checks don't trigger subsequent refreshes
+		c.cacheMutex.Lock()
+		c.cacheWriteTime = time.Now()
+		c.cacheMutex.Unlock()
+
+		// Asynchronously refresh the cache because we already have subnets in memory
+		go c.RefreshCache()
 	}
 
-	for _, subNet := range subNets {
+	c.cacheMutex.RLock()
+	// Ensure cache refreshes above were successful
+	if len(c.subnetCache) == 0 {
+		c.cacheMutex.RUnlock()
+		return nil, ErrCacheNotReady
+	}
+
+	for _, subNet := range c.subnetCache {
 		if subNet.Subnet.Contains(ip) {
+			c.cacheMutex.RUnlock()
 			return subNet, nil
 		}
 	}
 
+	c.cacheMutex.RUnlock()
 	return nil, ErrNotCloudIP
+}
+
+// Refreshes the cloud provider subnet cache first form disk (if available) and then from the web
+func (c *Client) RefreshCache() (err error) {
+	if c.CacheFilePath != "" {
+		// Always check the local cache first, it may have been updated by another process
+		if err = c.refreshCacheFromDisk(); err == nil {
+			if c.cacheWriteTime.Add(c.TTL).Before(time.Now()) {
+				// The local cache is still up to date
+				return nil
+			}
+		}
+
+		if stat, err := os.Stat(c.lockFilePath()); err == nil {
+			// Another process is refreshing the cache, ensure it's not an old lock file
+			if stat.ModTime().Add(c.TTL).Before(time.Now()) {
+				// The lock file has existed longer than expected
+				os.Remove(c.lockFilePath())
+				// Restart and generate a new lock file
+				return c.RefreshCache()
+			}
+
+			start := time.Now()
+			for start.Add(c.TTL).After(time.Now()) {
+				time.Sleep(5 * time.Second)
+				if _, err := os.Stat(c.lockFilePath()); os.IsNotExist(err) {
+					// Lock file has been removed, refresh the cache from disk
+					return c.refreshCacheFromDisk()
+				}
+			}
+
+			// The other process didn't successfully refresh the cache, await the next interval of refresh cache
+			return ErrCacheFileLocked
+		}
+
+		// This process is the one responsible for the lock file refresh.
+		if lockFile, err := os.OpenFile(c.lockFilePath(), os.O_RDONLY|os.O_CREATE, os.ModePerm); err == nil {
+			// We don't need to interact with the file, so we can close it immediately.
+			lockFile.Close()
+			defer os.Remove(lockFile.Name())
+		}
+	}
+
+	// Refresh the cache from the web
+	subnetCache := []*Response{}
+
+	amazon, err := getAmazonCIDRs()
+	if err != nil {
+		return err
+	}
+	subnetCache = append(subnetCache, amazon...)
+
+	google, err := getGoogleCIDRs()
+	if err != nil {
+		return err
+	}
+	subnetCache = append(subnetCache, google...)
+
+	microsoft, err := getMicrosoftCIDRs()
+	if err != nil {
+		return err
+	}
+	subnetCache = append(subnetCache, microsoft...)
+
+	if c.CacheFilePath != "" {
+		cache := diskCache{
+			SubnetCache: subnetCache,
+		}
+		// The > 2 check is to ensure we're not serializing an empty JSON file, i.e. {}
+		if data, err := json.MarshalIndent(cache, "", "  "); err == nil && len(data) > 2 {
+			ioutil.WriteFile(c.CacheFilePath, data, os.ModePerm)
+		}
+	}
+
+	c.cacheMutex.Lock()
+	c.subnetCache = subnetCache
+	c.cacheWriteTime = time.Now()
+	c.cacheSource = cacheSourceWeb
+	c.cacheMutex.Unlock()
+
+	return nil
+}
+
+func (c *Client) lockFilePath() (lfp string) {
+	return fmt.Sprintf("%s.lock", c.CacheFilePath)
+}
+
+// Refreshes the cloud provider subnet cache from the local cache file
+func (c *Client) refreshCacheFromDisk() (err error) {
+	f, err := os.OpenFile(c.CacheFilePath, os.O_RDONLY, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	var cache diskCache
+	err = json.Unmarshal(data, &cache)
+	if err != nil {
+		return err
+	}
+
+	c.cacheMutex.Lock()
+	c.subnetCache = cache.SubnetCache
+	if stat, err := f.Stat(); err == nil {
+		c.cacheWriteTime = stat.ModTime()
+	}
+	c.cacheSource = cacheSourceDisk
+	c.cacheMutex.Unlock()
+
+	return nil
+}
+
+// The number of cloud provider subnets loaded in the cache
+func (c *Client) Count() (subnetCount int) {
+	return len(c.subnetCache)
 }

--- a/clouddetect.go
+++ b/clouddetect.go
@@ -5,10 +5,16 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"os"
 	"sync"
 	"time"
+)
+
+var (
+	DefaultCacheRefreshTimeout time.Duration = 2 * time.Minute
+	logger                     *Logger       = &Logger{false}
 )
 
 // Client will eventually hold cache of IP ranges
@@ -21,8 +27,9 @@ type Client struct {
 	cacheRefreshInProgress bool
 
 	// Time to keep IP ranges cached for (default 12 hours)
-	TTL           time.Duration
-	CacheFilePath string
+	TTL                 time.Duration
+	CacheFilePath       string
+	CacheRefreshTimeout time.Duration
 }
 
 type diskCache struct {
@@ -39,8 +46,10 @@ type Response struct {
 var (
 	// ErrNotCloudIP is error returned when IP does not match any of the published list of ranges
 	ErrNotCloudIP = errors.New("not resolved to any known cloud IP range")
-	// ErrCacheFileLocked is returned when a RefreshCache call times out due to the presence of a lock file
-	ErrCacheFileLocked = errors.New("cache lock file exists, skipping cache refresh")
+	// ErrCacheRefreshInProgress is returned when RefreshCache is called while an existing refresh is occurring
+	ErrCacheRefreshInProgress = errors.New("cache refresh is already in progress")
+	// ErrDiskCacheExpired is returned when trying to refresh from disk with a file that has exceeded the TTL
+	ErrDiskCacheExpired = errors.New("cache on disk is expired")
 )
 
 const (
@@ -57,8 +66,9 @@ const (
 // NewClient generates a Client with specified cache TTL
 func NewClient(TTL time.Duration) *Client {
 	return &Client{
-		TTL:        TTL,
-		cacheMutex: &sync.RWMutex{},
+		TTL:                 TTL,
+		cacheMutex:          &sync.RWMutex{},
+		CacheRefreshTimeout: DefaultCacheRefreshTimeout,
 	}
 }
 
@@ -81,164 +91,265 @@ func Resolve(ip net.IP) (*Response, error) {
 // cloud providers' published IP ranges and any extra metadata that may be of use.
 // It returns ErrNotCloudIP if the IP does not resolve against any lists
 func (c *Client) Resolve(ip net.IP) (response *Response, err error) {
+	self := "clouddetect.Resolve"
+
 	c.cacheMutex.RLock()
 	if len(c.subnetCache) == 0 || c.cacheWriteTime.Add(c.TTL).Before(time.Now()) {
-		isFirstRun := len(c.subnetCache) == 0
 		c.cacheMutex.RUnlock()
+		logger.Printf("[%s] Cloud IP cache may need to be refreshed", self)
 
-		if isFirstRun {
-			// Synchronously refresh the cache
-			c.RefreshCache()
+		// Only allow one thread to actually trigger a cache refresh update
+		c.cacheMutex.Lock()
+		if c.cacheWriteTime.Add(c.TTL).Before(time.Now()) {
+			isFirstRun := len(c.subnetCache) == 0
+			logger.Printf("[%s] Cloud IP cache needs to be refreshed, isFirstRun = %t", self, isFirstRun)
+
+			if isFirstRun {
+				// Synchronously refresh the cache because we don't yet have any subnets
+				c.refreshCache(true, c.cacheWriteTime)
+				c.cacheMutex.Unlock()
+				logger.Printf("[%s] Synchronously refreshed cache", self)
+			} else {
+				// Ensure future checks don't trigger subsequent refreshes
+				minModTime := c.cacheWriteTime
+				c.cacheWriteTime = time.Now()
+				c.cacheMutex.Unlock()
+
+				// Asynchronously refresh the cache because we already have subnets in memory
+				logger.Printf("[%s] Asynchronously refreshing cache", self)
+				go c.refreshCache(false, minModTime)
+			}
 		} else {
-			// Ensure future checks don't trigger subsequent refreshes
-			c.cacheMutex.Lock()
-			c.cacheWriteTime = time.Now()
+			logger.Printf("[%s] Another thread has already updated the cache", self)
 			c.cacheMutex.Unlock()
-
-			// Asynchronously refresh the cache because we already have subnets in memory
-			go c.RefreshCache()
 		}
+	} else {
+		// Cache does not need to be refreshed
+		c.cacheMutex.RUnlock()
 	}
 
 	c.cacheMutex.RLock()
-	for _, subNet := range c.subnetCache {
+	// Copy data so we don't hold the read-lock too long and prevent async RefreshCache from completing
+	subnets := c.subnetCache
+	c.cacheMutex.RUnlock()
+
+	for _, subNet := range subnets {
 		if subNet.Subnet.Contains(ip) {
-			c.cacheMutex.RUnlock()
 			return subNet, nil
 		}
 	}
-	c.cacheMutex.RUnlock()
 
 	return nil, ErrNotCloudIP
 }
 
 // RefreshCache loads the cloud provider subnet data from disk (if available) and then from the web
 func (c *Client) RefreshCache() (err error) {
-	c.cacheMutex.Lock()
-	c.cacheRefreshInProgress = true
-	c.cacheMutex.Unlock()
-	defer func() {
-		c.cacheMutex.Lock()
-		c.cacheRefreshInProgress = false
-		c.cacheMutex.Unlock()
-	}()
+	return c.refreshCache(false, c.cacheWriteTime)
+}
+func (c *Client) refreshCache(isMutexAlreadyLocked bool, minModTime time.Time) (err error) {
+	self := "clouddetect.refreshCache"
 
+	if !isMutexAlreadyLocked {
+		c.cacheMutex.Lock()
+	}
+	if c.cacheRefreshInProgress {
+		if !isMutexAlreadyLocked {
+			c.cacheMutex.Unlock()
+		}
+
+		logger.Printf("[%s] refreshCache called when refresh was already in progress, skipping second run\n", self)
+		return ErrCacheRefreshInProgress
+	}
+	// Refresh in progress is set to false again by the disk/web methods that actually write cache data
+	c.cacheRefreshInProgress = true
+	if !isMutexAlreadyLocked {
+		c.cacheMutex.Unlock()
+	}
+
+	logger.Printf("[%s] Refreshing cache of cloud IPs...\n", self)
 	if c.CacheFilePath != "" {
 		// Always check the local cache first, it may have been updated by another process
-		if err = c.refreshCacheFromDisk(c.cacheWriteTime); err == nil {
-			if c.cacheWriteTime.Add(c.TTL).Before(time.Now()) {
+		if err = c.refreshCacheFromDisk(isMutexAlreadyLocked, minModTime); err == nil {
+			if c.cacheWriteTime.Add(c.TTL).After(time.Now()) {
 				// The local cache is still up to date
+				logger.Printf("[%s] Local cache is up to date, using cache from disk\n", self)
 				return nil
+			} else {
+				logger.Printf("[%s] Local cache is not up to date, reloading cache from web\n", self)
 			}
+		} else if err == ErrDiskCacheExpired {
+			logger.Printf("[%s] Local cache is not up to date, reloading cache from web\n", self)
+		} else {
+			logger.Printf("[%s] Could not load cache from disk: %v\n", self, err)
 		}
 
 		if stat, err := os.Stat(c.lockFilePath()); err == nil {
+			logger.Printf("[%s] Found an existing lock file\n", self)
 			// Another process is refreshing the cache, ensure it's not an old lock file
 			if stat.ModTime().Add(c.TTL).Before(time.Now()) {
 				// The lock file has existed longer than expected
-				os.Remove(c.lockFilePath())
-				// Restart and generate a new lock file
-				return c.RefreshCache()
+				if err = os.Remove(c.lockFilePath()); err == nil {
+					logger.Printf("[%s] Existing lock file was expired, removed lock file, and refreshing cache from web\n", self)
+					return c.refreshCacheFromWeb(isMutexAlreadyLocked)
+				} else {
+					logger.Printf("[%s] Could not remove expired lock file, refreshing cache from web\n", self)
+					return c.refreshCacheFromWeb(isMutexAlreadyLocked)
+				}
 			}
 
 			start := time.Now()
-			for start.Add(c.TTL).After(time.Now()) {
+			for start.Add(c.CacheRefreshTimeout).After(time.Now()) {
 				time.Sleep(5 * time.Second)
-				if _, err := os.Stat(c.lockFilePath()); os.IsNotExist(err) {
+				logger.Printf("[%s] Waiting for another process to finish with lock file\n", self)
+				if _, err := os.Stat(c.lockFilePath()); err == nil {
+					continue
+				} else if os.IsNotExist(err) {
 					// Lock file has been removed, refresh the cache from disk, we pass time.Time{} to ensure we always use the disk data after a lock file is removed
-					return c.refreshCacheFromDisk(time.Time{})
+					logger.Printf("[%s] Lock file has been removed, refreshing cache from disk\n", self)
+					return c.refreshCacheFromDisk(isMutexAlreadyLocked, time.Time{})
+				} else {
+					// Unexpected error when checking for lock file
+					logger.Printf("[%s] Could not check status of lock file (%v), refreshing from web\n", self, err)
+					return c.refreshCacheFromWeb(isMutexAlreadyLocked)
 				}
 			}
 
 			// The other process didn't successfully refresh the cache, await the next interval of refresh cache
-			return ErrCacheFileLocked
+			logger.Printf("[%s] Lock file not processed after cache refresh timeout period, refreshing from web\n", self)
+			return c.refreshCacheFromWeb(isMutexAlreadyLocked)
 		}
 
 		// This process is the one responsible for the lock file refresh.
 		if lockFile, err := os.OpenFile(c.lockFilePath(), os.O_RDONLY|os.O_CREATE, os.ModePerm); err == nil {
 			// We don't need to interact with the file, so we can close it immediately.
 			lockFile.Close()
-			defer os.Remove(lockFile.Name())
+			logger.Printf("[%s] Created lock file, refreshing cache from web\n", self)
+			defer func() {
+				if err := os.Remove(lockFile.Name()); err != nil {
+					logger.Printf("[%s] Could not remove lock file after completing refresh: %v\n", self, err)
+				}
+			}()
+		} else {
+			// Could not create lock file
+			logger.Printf("[%s] Could not create lock file, refreshing cache from web\n", self)
 		}
 	}
 
-	// Refresh the cache from the web
-	subnetCache := []*Response{}
-
-	amazon, err := getAmazonCIDRs()
-	if err != nil {
-		return err
-	}
-	subnetCache = append(subnetCache, amazon...)
-
-	google, err := getGoogleCIDRs()
-	if err != nil {
-		return err
-	}
-	subnetCache = append(subnetCache, google...)
-
-	microsoft, err := getMicrosoftCIDRs()
-	if err != nil {
-		return err
-	}
-	subnetCache = append(subnetCache, microsoft...)
-
-	if c.CacheFilePath != "" {
-		cache := diskCache{
-			SubnetCache: subnetCache,
-		}
-		// The > 2 check is to ensure we're not serializing an empty JSON file, i.e. {}
-		if data, err := json.MarshalIndent(cache, "", "  "); err == nil && len(data) > 2 {
-			ioutil.WriteFile(c.CacheFilePath, data, os.ModePerm)
-		}
-	}
-
-	c.cacheMutex.Lock()
-	c.subnetCache = subnetCache
-	c.cacheWriteTime = time.Now()
-	c.cacheSource = cacheSourceWeb
-	c.cacheMutex.Unlock()
-
-	return nil
+	return c.refreshCacheFromWeb(isMutexAlreadyLocked)
 }
 
 func (c *Client) lockFilePath() (lfp string) {
 	return fmt.Sprintf("%s.lock", c.CacheFilePath)
 }
 
-func (c *Client) refreshCacheFromDisk(minModTime time.Time) (err error) {
+func (c *Client) refreshCacheFromWeb(isMutexAlreadyLocked bool) (err error) {
+	// Refresh the cache from the web
+	subnetCache := []*Response{}
+	self := "clouddetect.refreshCacheFromWeb"
+
+	logger.Printf("[%s] Downloading Amazon CIDRs...\n", self)
+	amazon, err := getAmazonCIDRs()
+	if err != nil {
+		logger.Printf("[%s] Could not download Amazon CIDRs: %v\n", self, err)
+		return err
+	}
+	subnetCache = append(subnetCache, amazon...)
+
+	logger.Printf("[%s] Downloading Google CIDRs...\n", self)
+	google, err := getGoogleCIDRs()
+	if err != nil {
+		logger.Printf("[%s] Could not download Google CIDRs: %v\n", self, err)
+		return err
+	}
+	subnetCache = append(subnetCache, google...)
+
+	logger.Printf("[%s] Downloading Microsoft CIDRs...\n", self)
+	microsoft, err := getMicrosoftCIDRs()
+	if err != nil {
+		logger.Printf("[%s] Could not download Microsoft CIDRs: %v\n", self, err)
+		return err
+	}
+	subnetCache = append(subnetCache, microsoft...)
+
+	if c.CacheFilePath != "" {
+		logger.Printf("[%s] Saving subnetCache to disk...\n", self)
+		cache := diskCache{
+			SubnetCache: subnetCache,
+		}
+		// The > 2 check is to ensure we're not serializing an empty JSON file, i.e. {}
+		if data, err := json.MarshalIndent(cache, "", "  "); err == nil && len(data) > 2 {
+			if err = ioutil.WriteFile(c.CacheFilePath, data, os.ModePerm); err != nil {
+				logger.Printf("[%s] Could not write cache file (%s): %v\n", self, c.CacheFilePath, err)
+			}
+		} else {
+			logger.Printf("[%s] Could not marshal cache data to JSON: %v\n", self, err)
+		}
+	}
+
+	logger.Printf("[%s] Updating client cache properties...\n", self)
+	if !isMutexAlreadyLocked {
+		c.cacheMutex.Lock()
+	}
+	c.subnetCache = subnetCache
+	c.cacheWriteTime = time.Now()
+	c.cacheSource = cacheSourceWeb
+	c.cacheRefreshInProgress = false
+	if !isMutexAlreadyLocked {
+		c.cacheMutex.Unlock()
+	}
+	logger.Printf("[%s] Finished refreshing cache from web\n", self)
+
+	return nil
+}
+
+func (c *Client) refreshCacheFromDisk(isMutexAlreadyLocked bool, minModTime time.Time) (err error) {
+	self := "clouddetect.refreshCacheFromDisk"
+
 	f, err := os.OpenFile(c.CacheFilePath, os.O_RDONLY, os.ModePerm)
 	if err != nil {
+		if err != os.ErrNotExist {
+			logger.Printf("[%s] Could not open cache file path (%s): %v\n", self, c.CacheFilePath, err)
+		}
 		return err
 	}
 	defer f.Close()
 
+	logger.Printf("[%s] Checking mod time for cache file...\n", self)
 	var modTime time.Time
 	if stat, err := f.Stat(); err != nil {
+		logger.Printf("[%s] Could not call Stat(): %v\n", self, err)
 		return err
 	} else if modTime = stat.ModTime(); minModTime.After(modTime) {
 		// The local disk cache needs to be refreshed too
-		return nil
+		logger.Printf("[%s] Local disk cache needs to be refreshed too, skipping disk refresh\n", self)
+		return ErrDiskCacheExpired
 	}
 
 	data, err := ioutil.ReadAll(f)
 	if err != nil {
+		logger.Printf("[%s] Could not read data from cache file: %v\n", self, err)
 		return err
 	}
 
 	var cache diskCache
 	err = json.Unmarshal(data, &cache)
 	if err != nil {
+		logger.Printf("[%s] Could not unmarshal cache data: %v\n", self, err)
 		return err
 	}
 
-	c.cacheMutex.Lock()
+	logger.Printf("[%s] Updating client cache properties...\n", self)
+	if !isMutexAlreadyLocked {
+		c.cacheMutex.Lock()
+	}
 	c.subnetCache = cache.SubnetCache
 	c.cacheWriteTime = modTime
 	c.cacheSource = cacheSourceDisk
-	// This is technically set twice by RefreshCache() and this method, but since we're writing cache data in this method, we should ensure this flag is accurate
 	c.cacheRefreshInProgress = false
-	c.cacheMutex.Unlock()
+	if !isMutexAlreadyLocked {
+		c.cacheMutex.Unlock()
+	}
+	logger.Printf("[%s] Finished refreshing cache from web\n", self)
 
 	return nil
 }
@@ -246,4 +357,14 @@ func (c *Client) refreshCacheFromDisk(minModTime time.Time) (err error) {
 // Count retruns the number of cloud provider subnets loaded in the cache
 func (c *Client) Count() (subnetCount int) {
 	return len(c.subnetCache)
+}
+
+type Logger struct {
+	Enabled bool
+}
+
+func (this *Logger) Printf(format string, v ...interface{}) {
+	if this.Enabled {
+		log.Printf(format, v...)
+	}
 }

--- a/clouddetect_test.go
+++ b/clouddetect_test.go
@@ -1,14 +1,16 @@
 package clouddetect
 
 import (
+	"io/ioutil"
 	"net"
+	"os"
+	"sync"
 	"testing"
+	"time"
 )
 
-func TestDetect(t *testing.T) {
-	client := DefaultClient()
-
-	testCases := []struct {
+var (
+	testCases = []struct {
 		providerName string
 		ip           string
 	}{
@@ -16,6 +18,10 @@ func TestDetect(t *testing.T) {
 		{ProviderGoogle, "146.148.34.2"},
 		{ProviderMicrosoft, "168.61.66.2"},
 	}
+)
+
+func TestDetect(t *testing.T) {
+	client := DefaultClient()
 
 	for _, tc := range testCases {
 		t.Run(tc.providerName, func(t *testing.T) {
@@ -34,4 +40,152 @@ func TestDetect(t *testing.T) {
 			t.Errorf("%v resolved incorrectly with %v", badIP, err)
 		}
 	})
+}
+
+func TestThatRefreshCacheToDiskWorks(t *testing.T) {
+	tempFile, err := ioutil.TempFile(os.TempDir(), "clouddetect_test")
+	if err != nil {
+		t.Errorf("Could not create temp file for cache output: %v", err)
+		return
+	}
+	// last-in, first-out
+	defer os.Remove(tempFile.Name())
+	defer tempFile.Close()
+
+	client := DefaultClient()
+	client.CacheFilePath = tempFile.Name()
+
+	if err := client.RefreshCache(); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if len(client.subnetCache) == 0 {
+		t.Error("client.subnetCache is empty, expected records.")
+		return
+	}
+	if stat, err := os.Stat(client.CacheFilePath); err != nil {
+		t.Errorf("Could not get cache file (%s) stat: %v", client.CacheFilePath, err)
+		return
+	} else if size := stat.Size(); size < 3 {
+		t.Errorf("Cache file is empty, but subnetCache contains %d records", len(client.subnetCache))
+		return
+	} else {
+		t.Logf("Found %d subnet records and saved to disk in %d bytes.", len(client.subnetCache), size)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.providerName, func(t *testing.T) {
+			ip := net.ParseIP(tc.ip)
+			match, err := client.Resolve(ip)
+			if err != nil || match.ProviderName != tc.providerName {
+				t.Errorf("Expected %v to resolve to %v, got %#v:%#v", ip, tc.providerName, match, err)
+			}
+		})
+	}
+
+	t.Logf("Successfully resolved %d test cases", len(testCases))
+}
+
+func TestThatMultiProcessRefreshCacheFromDiskWorks(t *testing.T) {
+	tempFile, err := ioutil.TempFile(os.TempDir(), "clouddetect_test")
+	if err != nil {
+		t.Errorf("Could not create temp file for cache output: %v", err)
+		return
+	}
+	// last-in, first-out
+	defer os.Remove(tempFile.Name())
+	defer tempFile.Close()
+
+	client1 := NewClient(12 * time.Hour)
+	client1.CacheFilePath = tempFile.Name()
+
+	client2 := NewClient(12 * time.Hour)
+	client2.CacheFilePath = client1.CacheFilePath
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		if err := client1.RefreshCache(); err != nil {
+			t.Errorf("Client1: RefreshCache failed: %v", err)
+		}
+		wg.Done()
+	}()
+
+	// Ensure the lock file exists
+	time.Sleep(1 * time.Second)
+	if _, err := os.Stat(client1.lockFilePath()); os.IsNotExist(err) {
+		t.Errorf("Expected lock file to exist after starting initial RefreshCache gorouting, but file stat returned: %v", err)
+	}
+
+	wg.Add(1)
+	go func() {
+		if err := client2.RefreshCache(); err != nil {
+			t.Errorf("Client2: RefreshCache failed: %v", err)
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+	t.Logf("Finished refreshing cache via 2 goroutines. Found %d subnet records.", len(client1.subnetCache))
+
+	if _, err := os.Stat(client1.lockFilePath()); !os.IsNotExist(err) {
+		t.Errorf("Expected lock file IsNotExist err value after refresh cache call, but file stat returned: %v", err)
+	}
+
+	// Ensure the first process reloaded from the web
+	if client1.cacheSource != cacheSourceWeb {
+		t.Errorf("Expected client1 cache source to be %s, but received %s", cacheSourceWeb, client1.cacheSource)
+	}
+	if client2.cacheSource != cacheSourceDisk {
+		t.Errorf("Expected client2 cache source to be %s, but received %s", cacheSourceDisk, client2.cacheSource)
+	}
+	if len(client1.subnetCache) != len(client2.subnetCache) {
+		t.Errorf("Expected client1 subnetCache count (%d) to match client2 subnetCache count (%d), but it didn't", len(client1.subnetCache), len(client2.subnetCache))
+	}
+}
+
+func TestThatDeleteOldLockFileWorks(t *testing.T) {
+	tempFile, err := ioutil.TempFile(os.TempDir(), "clouddetect_test")
+	if err != nil {
+		t.Errorf("Could not create temp file for cache output: %v", err)
+		return
+	}
+	// last-in, first-out
+	defer os.Remove(tempFile.Name())
+	defer tempFile.Close()
+
+	client := DefaultClient()
+	client.CacheFilePath = tempFile.Name()
+
+	f, err := os.OpenFile(client.lockFilePath(), os.O_RDONLY|os.O_CREATE, os.ModePerm)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	f.Close()
+
+	if err = os.Chtimes(client.lockFilePath(), time.Now().Add(-24*time.Hour), time.Now().Add(-24*time.Hour)); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := client.RefreshCache(); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if len(client.subnetCache) == 0 {
+		t.Error("client.subnetCache is empty, expected records.")
+		return
+	}
+	if stat, err := os.Stat(client.CacheFilePath); err != nil {
+		t.Errorf("Could not get cache file (%s) stat: %v", client.CacheFilePath, err)
+		return
+	} else if size := stat.Size(); size < 3 {
+		t.Errorf("Cache file is empty, but subnetCache contains %d records", len(client.subnetCache))
+		return
+	} else {
+		t.Logf("Found %d subnet records and saved to disk in %d bytes.", len(client.subnetCache), size)
+	}
 }


### PR DESCRIPTION
This pull request adds support for persisting the subnet cache to disk. It also creates a lock file to allow multiple instances to share the same subnet cache file. Finally, the subnet cache is refreshed asynchronously (from web or disk) when the TTL is expired.

Our use case is click tracking microservices. We wanted to do the cloud IP detection during the request handler, but wanted to limit any slowdown experienced by users.